### PR TITLE
Remove override of shred_payment_info

### DIFF
--- a/pretix_saferpay/payment.py
+++ b/pretix_saferpay/payment.py
@@ -706,17 +706,6 @@ class SaferpayMethod(BasePaymentProvider):
         else:
             return str(url)
 
-    def shred_payment_info(self, obj: OrderPayment):
-        if not obj.info:
-            return
-        d = json.loads(obj.info)
-        if "details" in d:
-            d["details"] = {k: "█" for k in d["details"].keys()}
-
-        d["_shredded"] = True
-        obj.info = json.dumps(d)
-        obj.save(update_fields=["info"])
-
 
 class SaferpayCC(SaferpayMethod):
     method = "creditcard"


### PR DESCRIPTION
Because this version of it seems to do nothing given the data that's stored in info_data (never has a "details" key). Removing causes the base implementation to be used that clears info_data completely. Alternative would be to create a working version of shred_payment_info.